### PR TITLE
Option to fail if any warnings occur

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ jobs:
 
 Basically just [look at this](https://github.com/FPtje/GLuaFixer#linter-options). All `lint_*` options are supported.
 Prettyprint options aren't supported because this is a Linter and not a Prettyprinter.
+
+**Fail on Warning:**\
+You can also configure the action to fail if even a single warning occurs.
+This is useful if you want to enforce consistent styles. To do so add the
+`failOnWarning: true` option to the workflow file. If you choose to omit this
+option, it will default to being disabled.\
+([Contribution](https://github.com/TASSIA710/action-glua-lint/pull/4) by [rafraser](https://github.com/rafraser))

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,11 @@ inputs:
     required: false
     default: '/'
 
+  failOnWarning:
+    description: 'Whether to fail if any warnings occur'
+    required: false
+    default: false
+
   lint_maxScopeDepth:
     description: 'lint_maxScopeDepth'
     required: false

--- a/index.js
+++ b/index.js
@@ -168,11 +168,8 @@ for (let i = 0; i < elements.length; i++) {
 }
 
 
-
-if (errorCount !== 0) {
-    message = ' Found ' + errorCount + ' error(s) and ' + warningCount + ' warning(s):\n' + message;
-    core.setFailed(message);
-} else if (warningCount !== 0 && (core.getInput('failOnWarning') === 'true')) {
+let failOnWarning = core.getInput('failOnWarning') === 'true';
+if (errorCount !== 0 || (failOnWarning && warningCount !== 0)) {
     message = ' Found ' + errorCount + ' error(s) and ' + warningCount + ' warning(s):\n' + message;
     core.setFailed(message);
 }

--- a/index.js
+++ b/index.js
@@ -172,6 +172,9 @@ for (let i = 0; i < elements.length; i++) {
 if (errorCount !== 0) {
     message = ' Found ' + errorCount + ' error(s) and ' + warningCount + ' warning(s):\n' + message;
     core.setFailed(message);
+} else if (warningCount !== 0 && (core.getInput('failOnWarning') === 'true')) {
+    message = ' Found ' + errorCount + ' error(s) and ' + warningCount + ' warning(s):\n' + message;
+    core.setFailed(message);
 }
 
 


### PR DESCRIPTION
Adds a new configuration option named 'failOnWarning' which will fail the action if any warnings occur. This is useful to enforce consistent style in larger projects.