### PR TITLE
Update GLuaFixer to 1.17.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 
 // Other constants
 const GLUA_LINT_TAG = '1.1.1';
-const GLUA_FIXER_TAG = '1.16.4';
+const GLUA_FIXER_TAG = '1.17.2';
 const REGEX = '([a-zA-Z_\\-\\/.]+):\\s\\[([a-zA-Z]+)\\]\\sline\\s([0-9]+),\\scolumn\\s([0-9]+)\\s-\\sline\\s([0-9]+),\\scolumn\\s([0-9]+):\\s+(.*)';
 
 


### PR DESCRIPTION
This resolves #6 by updating GLuaFixer to a newer version, relying on `libffi.so.7` instead of `libffi.so.6`.